### PR TITLE
fix(parse-css-in-js-to-inline-css): fix custom style with quotes parsing errors

### DIFF
--- a/.changeset/bright-colts-kick.md
+++ b/.changeset/bright-colts-kick.md
@@ -1,0 +1,5 @@
+---
+"md-to-react-email": patch
+---
+
+Fix: replace quotes in custom styles with html hex code

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ import { styles } from "./styles";
 
 function escapeQuotes(value: string) {
   if (value.includes('"')) {
-    return value.replace(/"/g, "'");
+    return value.replace(/"/g, "&#x27;");
   }
   return value;
 }


### PR DESCRIPTION
### Fix
This replaces all `"` with the html hex code in escaped code

