### PR TITLE
fix: escape quotes failing when value is not a string

### DIFF
--- a/.changeset/orange-tigers-kiss.md
+++ b/.changeset/orange-tigers-kiss.md
@@ -1,0 +1,5 @@
+---
+"md-to-react-email": patch
+---
+
+Fixes inner error for styles like `fontWeight: 500`

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import { RendererObject } from "marked";
 import { styles } from "./styles";
 
 function escapeQuotes(value: string) {
-  if (value.includes('"')) {
+  if (typeof value === 'string' && value.includes('"')) {
     return value.replace(/"/g, "&#x27;");
   }
   return value;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import { StylesType, initRendererProps } from "./types";
 import { RendererObject } from "marked";
 import { styles } from "./styles";
 
-function escapeQuotes(value: string) {
+function escapeQuotes(value: unknown) {
   if (typeof value === 'string' && value.includes('"')) {
     return value.replace(/"/g, "&#x27;");
   }


### PR DESCRIPTION
This is meant to address https://github.com/resend/react-email/issues/1632.

The issue was that the `escapeQuotes` was assuming that the received value
would always be a string, whereas it could be a number based on how React
treats values for styles. So even something like `fontWeight: 600` is a valid
style while still not being converted into `font-weight: 600px` when converted.

The fix was very simple, only checking for quotes to escape if the passed in value
is actually a string.
