### PR TITLE
fix: memory leak caused by how marked library custom renderer being used

### DIFF
--- a/.changeset/nine-steaks-tie.md
+++ b/.changeset/nine-steaks-tie.md
@@ -1,0 +1,5 @@
+---
+"md-to-react-email": patch
+---
+
+Fix memory leak caused by how Marked custom renderer was used

--- a/__tests__/emailMarkdown.test.tsx
+++ b/__tests__/emailMarkdown.test.tsx
@@ -16,7 +16,7 @@ describe("ReactEmailMarkdown component renders correctly", () => {
     );
 
     expect(actualOutput).toMatchInlineSnapshot(
-      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><div><h1 style="font:700 23px / 32px 'Roobert PRO', system-ui, sans-serif">Hello, World!</h1><h2 style="background:url('path/to/image')">Hi, World</h2></div>"`
+      `"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><div><h1 style="font:700 23px / 32px &#x27;Roobert PRO&#x27;, system-ui, sans-serif">Hello, World!</h1><h2 style="background:url(&#x27;path/to/image&#x27;)">Hi, World</h2></div>"`
     );
   });
 });

--- a/__tests__/parseCssInJsToInlineCss.test.ts
+++ b/__tests__/parseCssInJsToInlineCss.test.ts
@@ -41,7 +41,7 @@ describe("parseCssInJsToInlineCss", () => {
     };
 
     const expectedOutput =
-      "font:700 23px / 32px 'Roobert PRO', system-ui, sans-serif;background:url('path/to/image')";
+      "font:700 23px / 32px &#x27;Roobert PRO&#x27;, system-ui, sans-serif;background:url('path/to/image')";
     expect(parseCssInJsToInlineCss(cssProperties)).toBe(expectedOutput);
   });
 });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,19 +1,15 @@
-import { marked, RendererObject } from "marked";
+import { marked, Renderer } from "marked";
 import { StylesType } from "./types";
 import { initRenderer } from "./utils";
 
 export class MarkdownParser {
-  private readonly renderer: RendererObject;
+  private readonly renderer: Renderer;
 
   constructor({ customStyles }: { customStyles?: StylesType }) {
     this.renderer = initRenderer({ customStyles });
   }
 
   parse(markdown: string) {
-    marked.use({
-      renderer: this.renderer,
-    });
-
-    return marked.parse(markdown);
+    return marked.parse(markdown, { renderer: this.renderer });
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import { CSSProperties } from "react";
 import { StylesType, initRendererProps } from "./types";
-import { RendererObject } from "marked";
+import { Renderer } from "marked";
 import { styles } from "./styles";
 
 function escapeQuotes(value: unknown) {
@@ -80,100 +80,99 @@ export function parseCssInJsToInlineCss(
 
 export const initRenderer = ({
   customStyles,
-}: initRendererProps): RendererObject => {
+}: initRendererProps): Renderer => {
   const finalStyles = { ...styles, ...customStyles };
 
-  const customRenderer: RendererObject = {
-    blockquote(quote) {
-      return `<blockquote${
-        parseCssInJsToInlineCss(finalStyles.blockQuote) !== ""
-          ? ` style="${parseCssInJsToInlineCss(finalStyles.blockQuote)}"`
-          : ""
-      }>\n${quote}</blockquote>\n`;
-    },
+  const customRenderer = new Renderer();
 
-    br() {
-      return `<br${
-        parseCssInJsToInlineCss(finalStyles.br) !== ""
-          ? ` style="${parseCssInJsToInlineCss(finalStyles.br)}"`
-          : ""
-      } />`;
-    },
+  customRenderer.blockquote = (quote) => {
+    return `<blockquote${
+      parseCssInJsToInlineCss(finalStyles.blockQuote) !== ""
+        ? ` style="${parseCssInJsToInlineCss(finalStyles.blockQuote)}"`
+        : ""
+    }>\n${quote}</blockquote>\n`;
+  }
 
-    code(code) {
-      code = code.replace(/\n$/, "") + "\n";
+  customRenderer.br = () => {
+    return `<br${
+      parseCssInJsToInlineCss(finalStyles.br) !== ""
+        ? ` style="${parseCssInJsToInlineCss(finalStyles.br)}"`
+        : ""
+    } />`;
+  }
 
-      return `<pre${
-        parseCssInJsToInlineCss(finalStyles.codeBlock) !== ""
-          ? ` style="${parseCssInJsToInlineCss(finalStyles.codeBlock)}"`
-          : ""
-      }><code>${code}</code></pre>\n`;
-    },
+  customRenderer.code = (code) => {
+    code = code.replace(/\n$/, "") + "\n";
 
-    codespan(text) {
-      return `<code${
-        parseCssInJsToInlineCss(finalStyles.codeInline) !== ""
-          ? ` style="${parseCssInJsToInlineCss(finalStyles.codeInline)}"`
-          : ""
-      }>${text}</code>`;
-    },
+    return `<pre${
+      parseCssInJsToInlineCss(finalStyles.codeBlock) !== ""
+        ? ` style="${parseCssInJsToInlineCss(finalStyles.codeBlock)}"`
+        : ""
+    }><code>${code}</code></pre>\n`;
+  }
 
-    del(text) {
-      return `<del${
-        parseCssInJsToInlineCss(finalStyles.strikethrough) !== ""
-          ? ` style="${parseCssInJsToInlineCss(finalStyles.strikethrough)}"`
-          : ""
-      }>${text}</del>`;
-    },
+  customRenderer.codespan = (text) => {
+    return `<code${
+      parseCssInJsToInlineCss(finalStyles.codeInline) !== ""
+        ? ` style="${parseCssInJsToInlineCss(finalStyles.codeInline)}"`
+        : ""
+    }>${text}</code>`;
+  }
 
-    em(text) {
-      return `<em${
-        parseCssInJsToInlineCss(finalStyles.italic) !== ""
-          ? ` style="${parseCssInJsToInlineCss(finalStyles.italic)}"`
-          : ""
-      }>${text}</em>`;
-    },
+  customRenderer.del = (text) => {
+    return `<del${
+      parseCssInJsToInlineCss(finalStyles.strikethrough) !== ""
+        ? ` style="${parseCssInJsToInlineCss(finalStyles.strikethrough)}"`
+        : ""
+    }>${text}</del>`;
+  }
 
-    heading(text, level) {
-      return `<h${level}${
-        parseCssInJsToInlineCss(
-          finalStyles[`h${level}` as keyof StylesType]
-        ) !== ""
-          ? ` style="${parseCssInJsToInlineCss(
-              finalStyles[`h${level}` as keyof StylesType]
-            )}"`
-          : ""
-      }>${text}</h${level}>`;
-    },
+  customRenderer.em = (text) => {
+    return `<em${
+      parseCssInJsToInlineCss(finalStyles.italic) !== ""
+        ? ` style="${parseCssInJsToInlineCss(finalStyles.italic)}"`
+        : ""
+    }>${text}</em>`;
+  }
 
-    hr() {
-      return `<hr${
-        parseCssInJsToInlineCss(finalStyles.hr) !== ""
-          ? ` style="${parseCssInJsToInlineCss(finalStyles.hr)}"`
-          : ""
-      } />\n`;
-    },
+  customRenderer.heading = (text, level) => {
+    return `<h${level}${
+      parseCssInJsToInlineCss(
+        finalStyles[`h${level}` as keyof StylesType]
+      ) !== ""
+        ? ` style="${parseCssInJsToInlineCss(
+            finalStyles[`h${level}` as keyof StylesType]
+          )}"`
+        : ""
+    }>${text}</h${level}>`;
+  }
 
-    image(href, _, text) {
-      let out = `<img src="${href}" alt="${text}"${
-        parseCssInJsToInlineCss(finalStyles.image) !== ""
-          ? ` style="${parseCssInJsToInlineCss(finalStyles.image)}"`
-          : ""
-      }>`;
-      return out;
-    },
+  customRenderer.hr = () => {
+    return `<hr${
+      parseCssInJsToInlineCss(finalStyles.hr) !== ""
+        ? ` style="${parseCssInJsToInlineCss(finalStyles.hr)}"`
+        : ""
+    } />\n`;
+  }
 
-    link(href, _, text) {
-      let out = `<a href="${href}" target="_blank"${
+  customRenderer.image = (href, _, text) => {
+    return `<img src="${href}" alt="${text}"${
+      parseCssInJsToInlineCss(finalStyles.image) !== ""
+        ? ` style="${parseCssInJsToInlineCss(finalStyles.image)}"`
+        : ""
+    }>`;
+  }
+
+  customRenderer.link = (href, _, text) => {
+    return `<a href="${href}" target="_blank"${
         parseCssInJsToInlineCss(finalStyles.link) !== ""
           ? ` style="${parseCssInJsToInlineCss(finalStyles.link)}"`
           : ""
       }>${text}</a>`;
-      return out;
-    },
+  }
 
-    list(body, ordered, start) {
-      const type = ordered ? "ol" : "ul";
+  customRenderer.list = (body, ordered, start) => {
+    const type = ordered ? "ol" : "ul";
       const startatt = ordered && start !== 1 ? ' start="' + start + '"' : "";
       const styles = parseCssInJsToInlineCss(
         finalStyles[ordered ? "ol" : "ul"]
@@ -188,34 +187,34 @@ export const initRenderer = ({
         type +
         ">\n"
       );
-    },
+  }
 
-    listitem(text) {
-      return `<li${
-        parseCssInJsToInlineCss(finalStyles.li) !== ""
-          ? ` style="${parseCssInJsToInlineCss(finalStyles.li)}"`
-          : ""
-      }>${text}</li>\n`;
-    },
+  customRenderer.listitem = (text) => {
+    return `<li${
+      parseCssInJsToInlineCss(finalStyles.li) !== ""
+        ? ` style="${parseCssInJsToInlineCss(finalStyles.li)}"`
+        : ""
+    }>${text}</li>\n`;
+  }
 
-    paragraph(text) {
-      return `<p${
-        parseCssInJsToInlineCss(finalStyles.p) !== ""
-          ? ` style="${parseCssInJsToInlineCss(finalStyles.p)}"`
-          : ""
-      }>${text}</p>\n`;
-    },
+  customRenderer.paragraph = (text) => {
+    return `<p${
+      parseCssInJsToInlineCss(finalStyles.p) !== ""
+        ? ` style="${parseCssInJsToInlineCss(finalStyles.p)}"`
+        : ""
+    }>${text}</p>\n`;
+  }
 
-    strong(text) {
-      return `<strong${
-        parseCssInJsToInlineCss(finalStyles.bold) !== ""
-          ? ` style="${parseCssInJsToInlineCss(finalStyles.bold)}"`
-          : ""
-      }>${text}</strong>`;
-    },
+  customRenderer.strong = (text) => {
+    return `<strong${
+      parseCssInJsToInlineCss(finalStyles.bold) !== ""
+        ? ` style="${parseCssInJsToInlineCss(finalStyles.bold)}"`
+        : ""
+    }>${text}</strong>`;
+  }
 
-    table(header, body) {
-      if (body) body = `<tbody>${body}</tbody>`;
+  customRenderer.table = (header, body) => {
+    if (body) body = `<tbody>${body}</tbody>`;
 
       return `<table${
         parseCssInJsToInlineCss(finalStyles.table) !== ""
@@ -226,10 +225,10 @@ export const initRenderer = ({
           ? ` style="${parseCssInJsToInlineCss(finalStyles.thead)}"`
           : ""
       }>\n${header}</thead>\n${body}</table>\n`;
-    },
+  }
 
-    tablecell(content, flags) {
-      const type = flags.header ? "th" : "td";
+  customRenderer.tablecell = (content, flags) => {
+    const type = flags.header ? "th" : "td";
       const tag = flags.align
         ? `<${type} align="${flags.align}"${
             parseCssInJsToInlineCss(finalStyles.td) !== ""
@@ -242,16 +241,15 @@ export const initRenderer = ({
               : ""
           }>`;
       return tag + content + `</${type}>\n`;
-    },
+  }
 
-    tablerow(content) {
-      return `<tr${
-        parseCssInJsToInlineCss(finalStyles.tr) !== ""
-          ? ` style="${parseCssInJsToInlineCss(finalStyles.tr)}"`
-          : ""
-      }>\n${content}</tr>\n`;
-    },
-  };
+  customRenderer.tablerow = (content) => {
+    return `<tr${
+      parseCssInJsToInlineCss(finalStyles.tr) !== ""
+        ? ` style="${parseCssInJsToInlineCss(finalStyles.tr)}"`
+        : ""
+    }>\n${content}</tr>\n`;
+  }
 
   return customRenderer;
 };


### PR DESCRIPTION
Hi,

We have been using react-email in production under fairly heavy load and have noticed a memory leak.

After some investigation I have narrowed it down to this repo and specifically how the underlying `marked` library is being used currently.

I found this in marked library documentation: "_Be careful: marked.use(...) should not be used in a loop or function. It should only be used directly after new Marked is created or marked is imported._" (here: https://marked.js.org/using_advanced).

And the above warning from the marked documentation seems to be violated here in this repo: https://github.com/codeskills-dev/md-to-react-email/blob/master/src/parser.ts#L13

I have updated the code to use an alternative way of calling marked with a custom renderer instance.

Here are some memory snapshots from a small test I ran (using clinic.js to analyze memory):
Before fix:
<img width="1506" alt="Screenshot 2024-11-18 at 15 47 35" src="https://github.com/user-attachments/assets/548711c3-c29a-4b8c-b561-793c925a7b88">

After fix:
<img width="1503" alt="Screenshot 2024-11-18 at 15 47 42" src="https://github.com/user-attachments/assets/e6eadb41-c5b7-404d-8e09-eecff5519c49">

You can see that the memory profile is flat after the changes have been made (before it would eventually just crash with OOM error).

I also took this screenshot from running our production code locally and load testing the application and you can see that it retains the marked.js instances and does not release them. Eventually these build up and cause the OOM errors:
![Screenshot 2024-11-12 at 14 26 29](https://github.com/user-attachments/assets/3b5ab01b-f3ab-4dd3-a74e-f7cc932425de)

I am not sure if more evidence is needed - I can push up my test case if you want? It was basically just calling `parseMarkdownToJSX` inside a nested loop thousands of times, similar to this (I used longer markdown example):

```
const { parseMarkdownToJSX } = require("./parseMarkdownToJSX");

const markdown = '## Lists'

async function testParse() {
  for (let i = 0; i < 800; i += 1) {
    for(let j = 0; j < 1000; j += 1) {
      parseMarkdownToJSX({ markdown });
    }
    await new Promise(r => setTimeout(r, 200));
    console.log('processed 1000, overall counter -> ', i);
  }
}

testParse()
  .then(() => {
    console.log('done');
  })
  .catch(err => {
    console.error('An error occurred:', err);
  });
  ```

Feel free to update my changes to modify what I have done (I don't have a lot of context on this codebase tbh). When I ran the tests locally all but one pass, and it fails snapshot test on quotes being encoded. However, this fails for me on master as well, so not too sure and might need advice on this.