### PR TITLE
fix: use correct styles for table header cells (`th`) vs data cells (`td`)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -229,18 +229,15 @@ export const initRenderer = ({
 
   customRenderer.tablecell = (content, flags) => {
     const type = flags.header ? "th" : "td";
-      const tag = flags.align
-        ? `<${type} align="${flags.align}"${
-            parseCssInJsToInlineCss(finalStyles.td) !== ""
-              ? ` style="${parseCssInJsToInlineCss(finalStyles.td)}"`
-              : ""
-          }>`
-        : `<${type}${
-            parseCssInJsToInlineCss(finalStyles.td) !== ""
-              ? ` style="${parseCssInJsToInlineCss(finalStyles.td)}"`
-              : ""
-          }>`;
-      return tag + content + `</${type}>\n`;
+    const styles = parseCssInJsToInlineCss(
+      finalStyles[flags.header ? "th" : "td"]
+    );
+    const tag = flags.align
+      ? `<${type} align="${flags.align}"${
+          styles !== "" ? ` style="${styles}"` : ""
+        }>`
+      : `<${type}${styles !== "" ? ` style="${styles}"` : ""}>`;
+    return tag + content + `</${type}>\n`;
   }
 
   customRenderer.tablerow = (content) => {


### PR DESCRIPTION
Previously, both ⁠`<th>` (header) and ⁠`<td>` (data) table cells were rendered using ⁠`finalStyles.td`, which meant header cell styles were ignored.
This PR updates the table cell renderer to check if the cell is a header or data cell, and applies the correct styles:
- Header cells (⁠`<th>`) now use ⁠`finalStyles.th` 	
- Data cells (⁠`<td>`) use ⁠`finalStyles.td`

This ensures that custom header styles are properly applied and not overridden by data cell styles.